### PR TITLE
Set directory name to lowercase (fixes build)

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -26,7 +26,7 @@ md5sums=('23dbf0e7ccf06d57f9beaeb297aa4c41'
 
 package() {
     install -d "$pkgdir"/opt
-    cp -R "$srcdir"/GitKraken "$pkgdir"/opt/gitkraken
+    cp -R "$srcdir"/gitkraken "$pkgdir"/opt/gitkraken
 
     find "$pkgdir"/opt/gitkraken/ -type f -exec chmod 644 {} \;
     chmod 755 "$pkgdir"/opt/gitkraken/gitkraken


### PR DESCRIPTION
1.7.0 build fails for me:

cp: cannot stat '/home/oliver/.cache/pacaur/gitkraken/src/GitKraken': No such file or directory

Possible fix:
Line 29 in PKGBUILD:
original:
cp -R "$srcdir"/GitKraken "$pkgdir"/opt/gitkraken
works for me:
cp -R "$srcdir"/gitkraken "$pkgdir"/opt/gitkraken 