### PR TITLE
Bump to v2.7.1-1

### DIFF
--- a/.SRCINFO
+++ b/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = gitkraken
 	pkgdesc = The intuitive, fast, and beautiful cross-platform Git client.
-	pkgver = 2.7.0
-	pkgrel = 2
+	pkgver = 2.7.1
+	pkgrel = 1
 	url = https://www.gitkraken.com/
 	arch = x86_64
 	license = custom
@@ -14,18 +14,16 @@ pkgbase = gitkraken
 	depends = libcurl-openssl-1.0
 	depends = libxss
 	provides = gitkraken
-	source = gitkraken-2.7.0.tar.gz::https://release.gitkraken.com/linux/v2.7.0.tar.gz
+	source = gitkraken-2.7.1.tar.gz::https://release.gitkraken.com/linux/v2.7.1.tar.gz
 	source = GitKraken.desktop
 	source = gitkraken.png
 	source = eula.html
 	source = gitkraken.sh
-	source = https://archive.archlinux.org/repos/2017/04/25/extra/os/x86_64/pango-1.40.5-1-x86_64.pkg.tar.xz
-	sha256sums = d6380a2ad29fdeeca05a4318f3c5db76db6a21c7359c34db6074a7a45cbc5301
+	sha256sums = 730b4e27babd38e4bc7a7ce1871db077ea2c0dd8698f5e6bc5dc49e32c353478
 	sha256sums = 5b3294331463f7fd983e78f8f54e293d66150b833db164ee1e4137e038846bc4
 	sha256sums = a2b3551f83bcbe56da961615f066bb736cd15d98e41c93b3b4add0d56606d902
 	sha256sums = 9566342308bf35b56e626fa1b0d716eb16991712cc43b617c4f0d95e005311d1
-	sha256sums = b9075ce7d891d05c229a083c5978557c5cb01c81b32b6220047f1a2f9963f5ac
-	sha256sums = 110df3af76a8a1751f30d7be988f4fa45b47448c96efce43f6d6c5474913c9f0
+	sha256sums = 28c1e28104c23937404448c38ee26dac75c01fb4398e1fad057599da24135b9e
 
 pkgname = gitkraken
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 pkg/
 src/
 gitkraken*.tar*
-*.tar*

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -6,8 +6,8 @@
 # Contributor: Victor Hugo Souza <vhbsouza@gmail.com>
 
 pkgname=gitkraken
-pkgrel=2
-pkgver=2.7.0
+pkgrel=1
+pkgver=2.7.1
 pkgdesc="The intuitive, fast, and beautiful cross-platform Git client."
 url="https://www.gitkraken.com/"
 provides=('gitkraken')
@@ -23,20 +23,16 @@ source=(
     "gitkraken.png"
     "eula.html"
     "gitkraken.sh"
-    "https://archive.archlinux.org/repos/2017/04/25/extra/os/x86_64/pango-1.40.5-1-x86_64.pkg.tar.xz"
 )
-sha256sums=('d6380a2ad29fdeeca05a4318f3c5db76db6a21c7359c34db6074a7a45cbc5301'
+sha256sums=('730b4e27babd38e4bc7a7ce1871db077ea2c0dd8698f5e6bc5dc49e32c353478'
             '5b3294331463f7fd983e78f8f54e293d66150b833db164ee1e4137e038846bc4'
             'a2b3551f83bcbe56da961615f066bb736cd15d98e41c93b3b4add0d56606d902'
             '9566342308bf35b56e626fa1b0d716eb16991712cc43b617c4f0d95e005311d1'
-            'b9075ce7d891d05c229a083c5978557c5cb01c81b32b6220047f1a2f9963f5ac'
-            '110df3af76a8a1751f30d7be988f4fa45b47448c96efce43f6d6c5474913c9f0')
+            '28c1e28104c23937404448c38ee26dac75c01fb4398e1fad057599da24135b9e')
 
 package() {
     install -d "$pkgdir"/opt
     cp -R "$srcdir"/gitkraken "$pkgdir"/opt/gitkraken
-
-    cp "$srcdir"/usr/lib/libpangoft2-1.0.so.0.4000.5 "$pkgdir"/opt/gitkraken
 
     find "$pkgdir"/opt/gitkraken/ -type f -exec chmod 644 {} \;
     chmod 755 "$pkgdir"/opt/gitkraken/gitkraken

--- a/gitkraken.sh
+++ b/gitkraken.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-LD_PRELOAD=/usr/lib/libcurl-openssl-1.0.so.4.4.0:/opt/gitkraken/libpangoft2-1.0.so.0.4000.5 /opt/gitkraken/gitkraken "$@"
+LD_PRELOAD=/usr/lib/libcurl-openssl-1.0.so.4.4.0 /opt/gitkraken/gitkraken "$@"


### PR DESCRIPTION
`GitKraken` v2.7.1 updated `electron` from v1.2.8 to v1.6.11, so #45 is not actual now
But `nodegit` still requires `libcurl` v3