### PR TITLE
Bump to v3.2.0-1

### DIFF
--- a/.SRCINFO
+++ b/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = gitkraken
 	pkgdesc = The intuitive, fast, and beautiful cross-platform Git client.
-	pkgver = 3.1.2
+	pkgver = 3.2.0
 	pkgrel = 1
 	url = https://www.gitkraken.com/
 	arch = x86_64
@@ -11,21 +11,21 @@ pkgbase = gitkraken
 	depends = libgnome-keyring
 	depends = gconf
 	depends = alsa-lib
-	depends = libcurl-gnutls
+	depends = libcurl-openssl-1.0
 	depends = libxss
 	depends = rtmpdump
 	optdepends = git-lfs: git-lfs support
 	provides = gitkraken
-	source = gitkraken-3.1.2.tar.gz::https://release.gitkraken.com/linux/v3.1.2.tar.gz
+	source = gitkraken-3.2.0.tar.gz::https://release.gitkraken.com/linux/v3.2.0.tar.gz
 	source = GitKraken.desktop
 	source = gitkraken.png
 	source = eula.html
 	source = gitkraken.sh
-	sha256sums = 9c5c4ac9d33978c9203b197c3829e564e13ec946a3eed3bf547cf9056363e1d2
+	sha256sums = 3466326d1359b9e8fb482ae9e4ce126cc56e65c8f1a02282946625eea7d8dbb8
 	sha256sums = c001122608370bc43d6cfefd8e217f337a07f544c351179e816983635f8ff45d
 	sha256sums = a2b3551f83bcbe56da961615f066bb736cd15d98e41c93b3b4add0d56606d902
 	sha256sums = 9566342308bf35b56e626fa1b0d716eb16991712cc43b617c4f0d95e005311d1
-	sha256sums = 1532caf9be612eddc57d0dcab94a71dcd6c5976f18b4555ba9740dcdc7f8b1d5
+	sha256sums = 28c1e28104c23937404448c38ee26dac75c01fb4398e1fad057599da24135b9e
 
 pkgname = gitkraken
 

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -7,13 +7,13 @@
 
 pkgname=gitkraken
 pkgrel=1
-pkgver=3.1.2
+pkgver=3.2.0
 pkgdesc="The intuitive, fast, and beautiful cross-platform Git client."
 url="https://www.gitkraken.com/"
 provides=('gitkraken')
 arch=('x86_64')
 license=('custom')
-depends=('gtk2' 'nss' 'libxtst' 'libgnome-keyring' 'gconf' 'alsa-lib' 'libcurl-gnutls' 'libxss' 'rtmpdump')
+depends=('gtk2' 'nss' 'libxtst' 'libgnome-keyring' 'gconf' 'alsa-lib' 'libcurl-openssl-1.0' 'libxss' 'rtmpdump')
 optdepends=('git-lfs: git-lfs support')
 makedepends=()
 backup=()
@@ -25,11 +25,11 @@ source=(
     "eula.html"
     "gitkraken.sh"
 )
-sha256sums=('9c5c4ac9d33978c9203b197c3829e564e13ec946a3eed3bf547cf9056363e1d2'
+sha256sums=('3466326d1359b9e8fb482ae9e4ce126cc56e65c8f1a02282946625eea7d8dbb8'
             'c001122608370bc43d6cfefd8e217f337a07f544c351179e816983635f8ff45d'
             'a2b3551f83bcbe56da961615f066bb736cd15d98e41c93b3b4add0d56606d902'
             '9566342308bf35b56e626fa1b0d716eb16991712cc43b617c4f0d95e005311d1'
-            '1532caf9be612eddc57d0dcab94a71dcd6c5976f18b4555ba9740dcdc7f8b1d5')
+            '28c1e28104c23937404448c38ee26dac75c01fb4398e1fad057599da24135b9e')
 
 package() {
     install -d "$pkgdir"/opt

--- a/gitkraken.sh
+++ b/gitkraken.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-exec /opt/gitkraken/gitkraken "$@"
+LD_PRELOAD=/usr/lib/libcurl-openssl-1.0.so.4.4.0 /opt/gitkraken/gitkraken "$@"


### PR DESCRIPTION
Now `nodegit` linked with `libcurl` again

P.S. Thank you @Axosoft for this hell!

**$** `ldd nodegit.node`

```
ldd: warning: you do not have execution permission for `./nodegit.node'
./nodegit.node: /usr/lib/libcurl.so.4: version `CURL_OPENSSL_3' not found (required by ./nodegit.node)
	linux-vdso.so.1 (0x00007fffc9d7a000)
	libcurl.so.4 => /usr/lib/libcurl.so.4 (0x00007efc27ae3000)
	libstdc++.so.6 => /usr/lib/libstdc++.so.6 (0x00007efc2775c000)
	libm.so.6 => /usr/lib/libm.so.6 (0x00007efc27410000)
	libgcc_s.so.1 => /usr/lib/libgcc_s.so.1 (0x00007efc271f9000)
	libpthread.so.0 => /usr/lib/libpthread.so.0 (0x00007efc26fdb000)
	libc.so.6 => /usr/lib/libc.so.6 (0x00007efc26c24000)
	libnghttp2.so.14 => /usr/lib/libnghttp2.so.14 (0x00007efc269fe000)
	libssh2.so.1 => /usr/lib/libssh2.so.1 (0x00007efc267d0000)
	libpsl.so.5 => /usr/lib/libpsl.so.5 (0x00007efc265c2000)
	libssl.so.1.1 => /usr/lib/libssl.so.1.1 (0x00007efc26358000)
	libcrypto.so.1.1 => /usr/lib/libcrypto.so.1.1 (0x00007efc25ed8000)
	libgssapi_krb5.so.2 => /usr/lib/libgssapi_krb5.so.2 (0x00007efc25c8b000)
	libkrb5.so.3 => /usr/lib/libkrb5.so.3 (0x00007efc259a5000)
	libk5crypto.so.3 => /usr/lib/libk5crypto.so.3 (0x00007efc25772000)
	libcom_err.so.2 => /usr/lib/libcom_err.so.2 (0x00007efc2556e000)
	libz.so.1 => /usr/lib/libz.so.1 (0x00007efc25357000)
	/usr/lib64/ld-linux-x86-64.so.2 (0x00007efc28514000)
	libicuuc.so.59 => /usr/lib/libicuuc.so.59 (0x00007efc24fa7000)
	libdl.so.2 => /usr/lib/libdl.so.2 (0x00007efc24da3000)
	libkrb5support.so.0 => /usr/lib/libkrb5support.so.0 (0x00007efc24b96000)
	libkeyutils.so.1 => /usr/lib/libkeyutils.so.1 (0x00007efc24992000)
	libresolv.so.2 => /usr/lib/libresolv.so.2 (0x00007efc2477b000)
	libicudata.so.59 => /usr/lib/libicudata.so.59 (0x00007efc22c68000)
```
