### PR TITLE
Use a different, version-independent way to use the right libcurl

### DIFF
--- a/.SRCINFO
+++ b/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = gitkraken
 	pkgdesc = The intuitive, fast, and beautiful cross-platform Git client.
 	pkgver = 3.3.2
-	pkgrel = 1
+	pkgrel = 2
 	url = https://www.gitkraken.com/
 	arch = x86_64
 	license = custom
@@ -25,7 +25,7 @@ pkgbase = gitkraken
 	sha256sums = c001122608370bc43d6cfefd8e217f337a07f544c351179e816983635f8ff45d
 	sha256sums = a2b3551f83bcbe56da961615f066bb736cd15d98e41c93b3b4add0d56606d902
 	sha256sums = 9566342308bf35b56e626fa1b0d716eb16991712cc43b617c4f0d95e005311d1
-	sha256sums = 28c1e28104c23937404448c38ee26dac75c01fb4398e1fad057599da24135b9e
+	sha256sums = b8a5b0666dbdeac3f5a836ba3c9a53831e411d9459545c098a0fcdf85270b1e0
 
 pkgname = gitkraken
 

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -6,7 +6,7 @@
 # Contributor: Victor Hugo Souza <vhbsouza@gmail.com>
 
 pkgname=gitkraken
-pkgrel=1
+pkgrel=2
 pkgver=3.3.2
 pkgdesc="The intuitive, fast, and beautiful cross-platform Git client."
 url="https://www.gitkraken.com/"
@@ -29,7 +29,7 @@ sha256sums=('0d00b01b961b51677e1e600ed63d1831b7aadc39801f53916c4327e169874193'
             'c001122608370bc43d6cfefd8e217f337a07f544c351179e816983635f8ff45d'
             'a2b3551f83bcbe56da961615f066bb736cd15d98e41c93b3b4add0d56606d902'
             '9566342308bf35b56e626fa1b0d716eb16991712cc43b617c4f0d95e005311d1'
-            '28c1e28104c23937404448c38ee26dac75c01fb4398e1fad057599da24135b9e')
+            'b8a5b0666dbdeac3f5a836ba3c9a53831e411d9459545c098a0fcdf85270b1e0')
 
 package() {
     install -d "$pkgdir"/opt

--- a/gitkraken.sh
+++ b/gitkraken.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-LD_PRELOAD=/usr/lib/libcurl-openssl-1.0.so.4.4.0 /opt/gitkraken/gitkraken "$@"
+LD_LIBRARY_PATH=/usr/lib/libcurl-openssl-1.0 /opt/gitkraken/gitkraken "$@"


### PR DESCRIPTION
Hello,

I updated libcurl-openssl-1.0 today and the filename change broke this package.
I patched it so it selects the right libcurl file without relying of the .so filename.