### PR TITLE
Bump to v4.0.6-1 (Ubuntu 18.04+)

### DIFF
--- a/.SRCINFO
+++ b/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = gitkraken
 	pkgdesc = The intuitive, fast, and beautiful cross-platform Git client.
-	pkgver = 4.0.5
+	pkgver = 4.0.6
 	pkgrel = 1
 	url = https://www.gitkraken.com/
 	arch = x86_64
@@ -16,15 +16,16 @@ pkgbase = gitkraken
 	depends = rtmpdump
 	optdepends = git-lfs: git-lfs support
 	provides = gitkraken
-	source = gitkraken-4.0.5.tar.gz::https://release.axocdn.com/linux/GitKraken-v4.0.5.tar.gz
+	source = gitkraken-4.0.6.tar.gz::https://release.axocdn.com/linux/GitKraken-18.04-v4.0.6.tar.gz
 	source = GitKraken.desktop
 	source = gitkraken.png
 	source = eula.html
 	source = gitkraken.sh
-	sha256sums = 70511a1c7b255ee8769e857d0d7a2529f8213f8636a5e8b18e24cc318728192b
+	sha256sums = 41d5030cc2249519fedfc2b927c78ddba064c863db0195a3790fc3c9d95f7f7a
 	sha256sums = c001122608370bc43d6cfefd8e217f337a07f544c351179e816983635f8ff45d
 	sha256sums = a2b3551f83bcbe56da961615f066bb736cd15d98e41c93b3b4add0d56606d902
 	sha256sums = 9566342308bf35b56e626fa1b0d716eb16991712cc43b617c4f0d95e005311d1
 	sha256sums = 0346815a2d43887c2f7715384043ee9674c30eebd2d6cc4d9c788238cb8ce87e
 
 pkgname = gitkraken
+

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -8,7 +8,7 @@
 
 pkgname=gitkraken
 pkgrel=1
-pkgver=4.0.5
+pkgver=4.0.6
 pkgdesc="The intuitive, fast, and beautiful cross-platform Git client."
 url="https://www.gitkraken.com/"
 provides=('gitkraken')
@@ -20,13 +20,13 @@ makedepends=()
 backup=()
 install=''
 source=(
-    "${pkgname}-${pkgver}.tar.gz::https://release.axocdn.com/linux/GitKraken-v${pkgver}.tar.gz"
+    "${pkgname}-${pkgver}.tar.gz::https://release.axocdn.com/linux/GitKraken-18.04-v${pkgver}.tar.gz"
     "GitKraken.desktop"
     "gitkraken.png"
     "eula.html"
     "gitkraken.sh"
 )
-sha256sums=('70511a1c7b255ee8769e857d0d7a2529f8213f8636a5e8b18e24cc318728192b'
+sha256sums=('41d5030cc2249519fedfc2b927c78ddba064c863db0195a3790fc3c9d95f7f7a'
             'c001122608370bc43d6cfefd8e217f337a07f544c351179e816983635f8ff45d'
             'a2b3551f83bcbe56da961615f066bb736cd15d98e41c93b3b4add0d56606d902'
             '9566342308bf35b56e626fa1b0d716eb16991712cc43b617c4f0d95e005311d1'


### PR DESCRIPTION
GitKraken now have two builds:

- Ubuntu 14.04+
- Ubuntu 18.04+

From release notes:

> Fedora, CentOS, & RHEL users should utilize the `.tar.gz` built for Ubuntu LTS 18.04+.

So, I think that Arch Linux should use `.tar.gz` built for Ubuntu LTS 18.04+ too, but I can't find permanent link to this build.

This PR contains link to build for Ubuntu 14.04+. Both builds works perfect on Arch Linux. The only difference between build is `nodegit` binaries.

PS. Axosoft bump Electron version to v2.0.9, so you can launch GitKraken via system electron.