### PR TITLE
Allow opening paths

### DIFF
--- a/GitKraken.desktop
+++ b/GitKraken.desktop
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Name=GitKraken
 Comment=Unleash your repo
-Exec=gitkraken
+Exec=gitkraken %f
 Icon=gitkraken
 Terminal=false
 Type=Application

--- a/gitkraken.sh
+++ b/gitkraken.sh
@@ -1,3 +1,7 @@
-#!/bin/sh
+#!/bin/bash
 
-/opt/gitkraken/gitkraken "$@"
+if [[ "$#" == '1' && "${1:0:1}" != '-' ]]; then
+    exec /opt/gitkraken/gitkraken -p "$1"
+else
+    exec /opt/gitkraken/gitkraken "$@"
+fi


### PR DESCRIPTION
After this, “right click → open with GitKraken” actually starts it for that path.

## Details

https://github.com/Azd325/gitkraken/blob/40b7aa5b8137bbee64c7c806a77c3971f04b0a67/GitKraken.desktop#L4

The `%f` in the `Exec` line means “app can only handle one argument, and only paths, no URLs”.

https://github.com/Azd325/gitkraken/blob/40b7aa5b8137bbee64c7c806a77c3971f04b0a67/gitkraken.sh#L3-L7

A .desktop file will either add the path at the position of the `%f` or leave out that argument completely. And neither `gitkraken -p;` nor `gitkraken ./path` works, so the script had to be modified to be called like the .desktop spec expects. So I decided it adds `-p` when being called with a single positional argument.