### PR TITLE
Add suid bit to chrome-sandbox and make it executable

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -41,6 +41,7 @@ package() {
     find "$pkgdir"/opt/gitkraken/ -type f -exec chmod 644 {} \;
     chmod 755 "$pkgdir"/opt/gitkraken/gitkraken
     chmod 755 "$pkgdir"/opt/gitkraken/resources/app.asar.unpacked/src/js/redux/domain/AskPass/AskPass.sh
+    chmod 4755 "$pkgdir"/opt/gitkraken/chrome-sandbox
 
     install -d "$pkgdir"/usr/bin
 


### PR DESCRIPTION
Without this GitKraken won't start.

Error:
```
[26029:0520/102257.861041:FATAL:setuid_sandbox_host.cc(157)] The SUID sandbox helper binary was found, but is not configured correctly. Rather than run without sandboxing I'm aborting now. You need to make sure that /opt/gitkraken/chrome-sandbox is owned by root and has mode 4755.
Trace/Breakpoint ausgelöst (Speicherabzug geschrieben)
```
(the last line in german essentially says "trace/breakpoint triggered (core dumped)")

I'm a little bit uncomfortable with just giving a random proprietary application a capability of privilege escalation to root.
One alternative would be to require `chromium` as a dependency and use the sandbox binary from there (via symlink).