### PR TITLE
Make all checks green

### DIFF
--- a/.github/workflows/validate-package.yml
+++ b/.github/workflows/validate-package.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v2
       - name: Lint Code Base
-        uses: github/super-linter@v3
+        uses: github/super-linter@v3.17.1
         env:
           VALIDATE_ALL_CODEBASE: false
           VALIDATE_HTML: false


### PR DESCRIPTION
Fixes the github action workflow
Maybe best to avoid hardcoding to a version by using latest tag for package 