### PR TITLE
Fix GitKraken 8.0.0 build

### DIFF
--- a/gitkraken-aur/PKGBUILD
+++ b/gitkraken-aur/PKGBUILD
@@ -42,7 +42,6 @@ package() {
     chmod 755 "$pkgdir"/opt/gitkraken/resources/app.asar.unpacked/src/js/redux/domain/AskPass/AskPass.sh
     chmod 755 "$pkgdir"/opt/gitkraken/resources/app.asar.unpacked/resources/cli/unix/gk
     chmod 755 "$pkgdir"/opt/gitkraken/resources/app.asar.unpacked/resources/cli/unix/gkrc
-    chmod -R 755 "$pkgdir"/opt/gitkraken/resources/app.asar.unpacked/resources/cli/unix/helpers
     chmod 4755 "$pkgdir"/opt/gitkraken/chrome-sandbox
 
     install -d "$pkgdir"/usr/bin


### PR DESCRIPTION
The latest 8.0.0 release of GitKraken doesn't have `gitkraken/resources/app.asar.unpacked/resources/cli/unix/helpers` subfolder anymore. As a consequence, 8.0.0 build is broken (see https://aur.archlinux.org/packages/gitkraken/#comment-827782). The chmod on that folder is not needed anymore