### PR TITLE
Issue #260 | Desktop file incorrectly associates GitKraken with plaintext files.

### DIFF
--- a/gitkraken-aur/.SRCINFO
+++ b/gitkraken-aur/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = gitkraken
 	pkgdesc = The intuitive, fast, and beautiful cross-platform Git client.
 	pkgver = 11.2.1
-	pkgrel = 1
+	pkgrel = 2
 	url = https://www.gitkraken.com/
 	arch = x86_64
 	license = custom
@@ -19,7 +19,7 @@ pkgbase = gitkraken
 	source = eula.html
 	source = gitkraken.sh
 	sha256sums = 33fd10bd37d60d85c4b5b06c2359680392b4790c3f7822b0f074c277341fb05a
-	sha256sums = f4a63737eccf279b0b131fe34e4a711aaf0dd5be86e932baf2593069553ef3b1
+	sha256sums = 078fa2cdf6826d956bf73387fb2ef147b1aca5f4a7a3cb4be8c71e6105fc9c6c
 	sha256sums = 5b7b39b331bc32a606e1e79c695df4519c9b220225be00fb34ef368c3af319a6
 	sha256sums = c78ef86324946f856cc5c11549990722155a5e883dc94f92a95169c7ab5fb63e
 

--- a/gitkraken-aur/GitKraken.desktop
+++ b/gitkraken-aur/GitKraken.desktop
@@ -8,5 +8,4 @@ Terminal=false
 Type=Application
 StartupNotify=true
 Categories=GNOME;GTK;Development;RevisionControl;
-MimeType=text/plain;
 StartupWMClass=gitkraken

--- a/gitkraken-aur/PKGBUILD
+++ b/gitkraken-aur/PKGBUILD
@@ -30,7 +30,7 @@ source=(
     "gitkraken.sh"
 )
 sha256sums=('33fd10bd37d60d85c4b5b06c2359680392b4790c3f7822b0f074c277341fb05a'
-            'f4a63737eccf279b0b131fe34e4a711aaf0dd5be86e932baf2593069553ef3b1'
+            '078fa2cdf6826d956bf73387fb2ef147b1aca5f4a7a3cb4be8c71e6105fc9c6c'
             '5b7b39b331bc32a606e1e79c695df4519c9b220225be00fb34ef368c3af319a6'
             'c78ef86324946f856cc5c11549990722155a5e883dc94f92a95169c7ab5fb63e')
 options=('!strip' '!debug')

--- a/gitkraken-aur/PKGBUILD
+++ b/gitkraken-aur/PKGBUILD
@@ -4,13 +4,13 @@
 # Contributor: Samuel Littley <samuel@samuellittley.me>
 # Contributor: KillWolfVlad <github.com/KillWolfVlad>
 # Contributor: Victor Hugo Souza <vhbsouza@gmail.com>
-# Contributor: William Penton <william@penton.us>
+# Contributor: William Penton <william@nexxuz.co>
 # Contributor: Jeff Moody <jeff@fifthecho.com>
 # Contributor: KokaKiwi <kokakiwi+aur@kokakiwi.net>
 # Contributor: iBernd81 <aur at gempel dot bayern>
 
 pkgname=gitkraken
-pkgrel=1
+pkgrel=2
 pkgver=11.2.1
 pkgdesc="The intuitive, fast, and beautiful cross-platform Git client."
 url="https://www.gitkraken.com/"


### PR DESCRIPTION
https://github.com/Azd325/gitkraken/issues/260
Removes an unnecessary MimeType entry from the .desktop file to prevent text files from being associated with GitKraken.
