### PR TITLE
ci: switch back to upstream 2m/arch-pkgbuild-builder

### DIFF
--- a/.github/workflows/validate-package.yml
+++ b/.github/workflows/validate-package.yml
@@ -22,19 +22,17 @@ jobs:
 
       - name: Validate PKGBUILD
         id: validate-pkgbuild
-        uses: Azd325/arch-pkgbuild-builder@1df308b1218f91dd79a496b7dae1383b3bcb2d14
+        uses: 2m/arch-pkgbuild-builder@1e857b7a8cd3e37b29898833363bab7e621cdd7b # v1.21
         with:
           target: "pkgbuild"
-          builddir: "gitkraken-aur"
-          pkgname: "gitkraken"
+          pkgname: "gitkraken-aur"
 
       - name: Validate SRCINFO
         id: validate-srcinfo
-        uses: Azd325/arch-pkgbuild-builder@1df308b1218f91dd79a496b7dae1383b3bcb2d14
+        uses: 2m/arch-pkgbuild-builder@1e857b7a8cd3e37b29898833363bab7e621cdd7b # v1.21
         with:
           target: "srcinfo"
-          builddir: "gitkraken-aur"
-          pkgname: "gitkraken"
+          pkgname: "gitkraken-aur"
   sources:
     name: Verify ${{ matrix.arch }} source
     runs-on: ubuntu-latest


### PR DESCRIPTION
Retires the `Azd325/arch-pkgbuild-builder` fork in favor of upstream `2m/arch-pkgbuild-builder` (pinned to v1.21 by SHA).

## Why
The fork was created to work around the old upstream's aurpublish assumption that the package directory must be named after the package — our directory is `gitkraken-aur/` but the package is `gitkraken`. Upstream has since solved this differently: `pkgname` is now the **path to the build directory**, and the real package name is read from `.SRCINFO`. The fork is no longer needed.

The fork is **14 commits ahead, 83 behind** upstream and was last touched in 2023; upstream is actively maintained with proper version tags.

## Changes
- Both validation steps use `2m/arch-pkgbuild-builder@1e857b7` (v1.21).
- Dropped the fork-only `builddir` input; `pkgname` now points at the `gitkraken-aur` directory.

## Verification (in an Arch container)
- ✅ `pkgname` resolves to `gitkraken` read from `.SRCINFO`, despite the `gitkraken-aur/` directory name
- ✅ The empty-`validpgpkeys` gpg step exits cleanly under `set -e` (so the `pkgbuild` target does not break)

## Notes
- No arm64 gain — upstream still uses an amd64-only image, same as the fork.
- After merge, the `Azd325/arch-pkgbuild-builder` fork can be archived.
- Touches the same workflow file as #306; whichever merges second may need a trivial rebase.