### PR TITLE
gitkraken: bump pkgrel to 2 for aarch64 support

### DIFF
--- a/gitkraken-aur/.SRCINFO
+++ b/gitkraken-aur/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = gitkraken
 	pkgdesc = The intuitive, fast, and beautiful cross-platform Git client.
 	pkgver = 12.2.0
-	pkgrel = 1
+	pkgrel = 2
 	url = https://www.gitkraken.com/
 	arch = x86_64
 	arch = aarch64

--- a/gitkraken-aur/PKGBUILD
+++ b/gitkraken-aur/PKGBUILD
@@ -10,7 +10,7 @@
 # Contributor: iBernd81 <aur at gempel dot bayern>
 
 pkgname=gitkraken
-pkgrel=1
+pkgrel=2
 pkgver=12.2.0
 pkgdesc="The intuitive, fast, and beautiful cross-platform Git client."
 url="https://www.gitkraken.com/"


### PR DESCRIPTION
Bumps `pkgrel` 1 → 2 ahead of publishing the aarch64-enabled package to the AUR.

## Why
aarch64 support (#306) landed at the same `pkgver` (12.2.0), modifying the published PKGBUILD/.SRCINFO without a version change — exactly the case `pkgrel` covers. Per Arch convention, a changed package definition at the same `pkgver` gets a `pkgrel` bump.

- **x86_64**: package content is byte-identical; this is a one-time, harmless rebuild.
- **aarch64**: newly installable.

The auto-update `update.sh` resets `pkgrel=1` on the next real upstream version bump, so this `-2` only covers the interim release that adds the architecture.

## Changes
- `PKGBUILD`: `pkgrel=2`
- `.SRCINFO`: regenerated via `makepkg --printsrcinfo` (only the `pkgrel` line changes)